### PR TITLE
Fix infinite-recursion methods

### DIFF
--- a/common/src/main/java/io/github/orlouge/structurepalettes/proxy/StructureWorldAccessProxy.java
+++ b/common/src/main/java/io/github/orlouge/structurepalettes/proxy/StructureWorldAccessProxy.java
@@ -106,7 +106,7 @@ public class StructureWorldAccessProxy implements StructureWorldAccess {
 
     @Override
     public MinecraftServer getServer() {
-        return this.getServer();
+        return this.world.getServer();
     }
 
     @Override
@@ -161,7 +161,7 @@ public class StructureWorldAccessProxy implements StructureWorldAccess {
 
     @Override
     public WorldBorder getWorldBorder() {
-        return this.getWorldBorder();
+        return this.world.getWorldBorder();
     }
 
     @Override


### PR DESCRIPTION
Fixes two StructureWorldAccessProxy methods that called themselves instead of calling the equivalent methods on this.world, causing stack overflow crashes